### PR TITLE
Second pass at #48

### DIFF
--- a/members/K000380.yaml
+++ b/members/K000380.yaml
@@ -37,18 +37,6 @@ contact_form:
           selector: "#required-city"
           value: $ADDRESS_CITY
           required: true
-        - name: required-state
-          selector: "#required-state"
-          value: $ADDRESS_STATE_POSTAL_ABBREV
-          required: true
-        - name: required-zip5
-          selector: "#required-zip5"
-          value: $ADDRESS_ZIP5
-          required: true
-        - name: zip4
-          selector: "#zip4"
-          value: $ADDRESS_ZIP4
-          required: false
         - name: required-valid-email
           selector: "#required-valid-email"
           value: $EMAIL


### PR DESCRIPTION
Fix error finding state/zip code fields:

The state and ZIP code fields in the second form are auto-filled from the initial validating form, so presumably we don't need them in the second.
