### PR TITLE
Update K000362.yaml

### DIFF
--- a/members/K000362.yaml
+++ b/members/K000362.yaml
@@ -84,4 +84,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: I appreciate hearing from you on federal issues that are important to you.
+      contains: Your email should automatically be sent in a few seconds.


### PR DESCRIPTION
Change the success message to the text that appears on a intermediary screen. Since validation is done on the client side, it appears that seeing the text 'Your email should automatically be sent in a few seconds' signifies the submission was successful.
