### PR TITLE
change confirmation message

### DIFF
--- a/members/C001096.yaml
+++ b/members/C001096.yaml
@@ -109,4 +109,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: Email Me - Thank You
+      contains: EMAIL ME - THANK YOU


### PR DESCRIPTION
The page displays the message in all caps, while the source code had it in traditional title case. Test appears to be getting to the success page while still showing 'failure'. Switching it to the all-caps format to see if that fixes the issue.
