### PR TITLE
Fixing field issue with D000617 (#100).

### DIFF
--- a/members/D000617.yaml
+++ b/members/D000617.yaml
@@ -43,18 +43,6 @@ contact_form:
           selector: "#required-city"
           value: $ADDRESS_CITY
           required: true
-        - name: required-state
-          selector: "#required-state"
-          value: $ADDRESS_STATE_POSTAL_ABBREV
-          required: true
-        - name: required-zip5
-          selector: "#required-zip5"
-          value: $ADDRESS_ZIP5
-          required: true
-        - name: zip4
-          selector: "#zip4"
-          value: $ADDRESS_ZIP4
-          required: true
         - name: required-valid-email
           selector: "#required-valid-email"
           value: $EMAIL


### PR DESCRIPTION
It appears that the state/zip4/zip5 on the final contact page is automatically filled, and since the forms test had issues finding `#required-state`, we'll just leave these fields as default.
