### PR TITLE
Fixing form submit issue with #155 (S000510).

### DIFF
--- a/members/S000510.yaml
+++ b/members/S000510.yaml
@@ -63,6 +63,9 @@ contact_form:
     - click_on:
         - value: Send Email
           selector: "form.migForm.zipform[name='contact'] input[name='submit']"
+    - click_on:
+        - value: Send Email
+          selector: "form.migForm.zipform[name='contact'] input[name='submit']"
   success:
     headers:
       status: 200


### PR DESCRIPTION
The contact form submit button does not immediately submit the form (at least on Chrome 34/Win7), however, clicking the button a second time does submit the form. congress-forms-test fails with a similar issue, so I'm submitting this in hopes that it fixes the problem.
