### PR TITLE
Fixes for bookmarklet, #828, #821

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -881,7 +881,9 @@ CCH.prototype.parentMain = function() {
     // we're on a form page, open the popup and inject the script
     this.popupWindow().ghAuthKey = this.ghAuthKey;
     var scr = this.popupWindow().document.createElement('script');
-    scr.src = this.scriptUrl;
+    scr.src = $('#cchbookmarklet').attr('src');
+    if (scr.src === undefined)
+      scr.src = this.scriptUrl;
     this.popupWindow().document.head.appendChild(scr);
   } else {
     // we're on a random page, add the select box


### PR DESCRIPTION
Three commits here, they are, in order:
- f83d110 : Fix for #821, adds another sort of generic forms.house.gov url to recognize.
- 96f6b46 : Fix for code merged in #828, there was a parameter left out.
- d21cc70 : Attempts to load the script in the popup from the same place as the bookmarklet, by naming the script tag `#cchbookmarklet`. This makes it possible to test changes to the bookmarklet. If no such script tag exists, it'll fall back to the s3 url.

As a result of that last, **any links to fixed bookmarklets must take a new form**. That new form, which points to the main repo bookmarklet.js, is this:

```
javascript:window.ghAuthKey='YzMzZGRhYjQyMTdiNGE4YWU1Y2IxNDM5ZmRiYWMwZDUxNWYwZDVjYzp4LW9hdXRoLWJhc2lj';(function(){var scr=document.createElement('script'); scr.id='cchbookmarklet'; scr.src='https://github.com/unitedstates/contact-congress/raw/gh-pages/bookmarklet.js'; document.head.appendChild(scr);})();
```
