### PR TITLE
Skipping zip checking for #344 (H000329).

### DIFF
--- a/members/H000329.yaml
+++ b/members/H000329.yaml
@@ -3,21 +3,7 @@ contact_form:
   method: post
   action: /submit-contact.aspx
   steps:
-    - visit: "http://hastings.house.gov/contact/"
-    - fill_in:
-        - name: zip5
-          selector: "#zip input[name='zip5']"
-          value: $ADDRESS_ZIP5
-          required: true
-        - name: zip4
-          selector: "#zip input[name='zip4']"
-          value: $ADDRESS_ZIP4
-          required: false
-    - click_on:
-        - value: Submit
-          selector: "#zip input[name='find']"
-    - find:
-        - selector: "form.zipform[name='contact']"
+    - visit: "https://hastings.house.gov/contact/contactform.htm"
     - fill_in:
         - name: required-prefix
           selector: "form.zipform[name='contact'] input[name='required-prefix']"
@@ -46,7 +32,7 @@ contact_form:
         - name: zip4
           selector: "form.zipform[name='contact'] input[name='zip4']"
           value: $ADDRESS_ZIP4
-          required: true
+          required: false
         - name: phone
           selector: "form.zipform[name='contact'] input[name='phone']"
           value: $PHONE


### PR DESCRIPTION
It appears that the zip code check form is not needed to submit the contact form. Skipping the check since I believe the HTTP -> HTTPS transition might be causing the congress-forms-test to fail.
