### PR TITLE
Removed hidden fields

### DIFF
--- a/members/S001165.yaml
+++ b/members/S001165.yaml
@@ -41,18 +41,6 @@ contact_form:
           selector: "#required-city"
           value: $ADDRESS_CITY
           required: true
-        - name: required-state
-          selector: "#required-state"
-          value: $ADDRESS_STATE_POSTAL_ABBREV
-          required: true
-        - name: required-zip5
-          selector: "#required-zip5"
-          value: $ADDRESS_ZIP5
-          required: true
-        - name: zip4
-          selector: "#zip4"
-          value: $ADDRESS_ZIP4
-          required: false
         - name: required-valid-email
           selector: "#contactForm input[name='required-valid-email']"
           value: $EMAIL


### PR DESCRIPTION
Integration test couldn't find hidden selectors #required-state, #required-zip5, and #zip4.  They are not meant to be edited during the 'Step Two - Write Your Message' section.
