### PR TITLE
Form is submitting --body contains was effecting

### DIFF
--- a/members/L000573.yaml
+++ b/members/L000573.yaml
@@ -103,4 +103,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: "Thank You    "
+      contains: "Thank"


### PR DESCRIPTION
Receiving this error from the current yaml. pushing to test if contains was the issue under body. Otherwise the form is being submitted but the tester is erroring.  

 Filling out the remote form was not successful
["/home/congressforms/congress-forms/app/models/congress_member.rb:52:in `fill_out_form'", "/home/congressforms/congress-forms/app/helpers/form_fill_handler.rb:15:in`block in create_thread'"]
