### PR TITLE
Update W000187.yaml

### DIFF
--- a/members/W000187.yaml
+++ b/members/W000187.yaml
@@ -29,10 +29,6 @@ contact_form:
           selector: "form.zipform[name='contact'] input[name='zip5']"
           value: $ADDRESS_ZIP5
           required: false
-        - name: zip4
-          selector: "form.zipform[name='contact'] input[name='zip4']"
-          value: $ADDRESS_ZIP4
-          required: false
         - name: phone
           selector: "form.zipform[name='contact'] input[name='phone']"
           value: $PHONE


### PR DESCRIPTION
With zip+4 field included, and mapped to the zip+4 field:
Unable to find css "form.zipform[name='contact'] input[name='zip4']"

So taking out zip+4 entirely...
