### PR TITLE
S000033: Several "Topic" options lead to error pages

### DIFF
--- a/members/S000033.yaml
+++ b/members/S000033.yaml
@@ -10,7 +10,6 @@ contact_form:
         value: "$TOPIC"
         required: Yes
         options:
-          - "Academy Nominations"
           - "Agriculture"
           - "Animal Rights"
           - "Appropriations"
@@ -19,7 +18,6 @@ contact_form:
           - "Budget"
           - "Business and Commerce"
           - "Campaign/Election Reform"
-          - "Casework"
           - "Census"
           - "Consumer Protection"
           - "Defense and Military"
@@ -28,9 +26,7 @@ contact_form:
           - "Energy"
           - "Environment"
           - "Ethics Reform"
-          - "Flag Requests"
           - "Foreign Relations"
-          - "Grant Letters"
           - "Guns"
           - "Healthcare"
           - "Homeland Security"
@@ -49,7 +45,6 @@ contact_form:
           - "Social Issues"
           - "Taxes"
           - "Technology and Telecom"
-          - "Tour Requests"
           - "Trade"
           - "Transportation"
           - "Veterans"


### PR DESCRIPTION
Several of the "Message Topic" options tell the user not to use the contact form for those purposes.  Since that means they're not really valid options, I've removed them from the topic list.
