### PR TITLE
Remove optional prefix field. #285

### DIFF
--- a/members/L000480.yaml
+++ b/members/L000480.yaml
@@ -66,19 +66,6 @@ contact_form:
           value: $MESSAGE
           required: true
     - select:
-        - name: prefix
-          selector: "#prefix"
-          value: $NAME_PREFIX
-          required: false
-          options:
-            Mr.: "Mr. "
-            Mrs.: Mrs.
-            Ms.: Ms.
-            Miss: Miss
-            Dr.: Dr.
-            Hon.: Hon.
-            Rev.: Rev.
-            Rabbi: Rabbi
         - name: state
           selector: "#req_state"
           value: $ADDRESS_STATE_POSTAL_ABBREV
@@ -165,7 +152,7 @@ contact_form:
             Other Issues: WEBOTH
     - click_on:
         - value: Send Email
-          selector: "#custom_form32 input.form_submit_button.filled"
+          selector: "#submitButton"
   success:
     headers:
       status: 200


### PR DESCRIPTION
Got the message:
Unable to find css "option" with text /^\$NAME_PREFIX$/
["/home/congressforms/congress-forms/app/models/congress_member.rb:45:in `rescue in fill_out_form'", "/home/congressforms/congress-forms/app/models/congress_member.rb:39:in`fill_out_form'", "/home/congressforms/congress-forms/app/helpers/form_fill_handler.rb:15:in `block in create_thread'"]

Took out the field to see if the form can be submitted.

Also, change the selector of submit button to #submit id
