### PR TITLE
Rename selector to email field again. #285

### DIFF
--- a/members/L000480.yaml
+++ b/members/L000480.yaml
@@ -50,7 +50,7 @@ contact_form:
           value: $ADDRESS_ZIP4
           required: false
         - name: emailaddress
-          selector: "#req_email"
+          selector: "#custom_form32 #req_email"
           value: $EMAIL
           required: true
         - name: phone


### PR DESCRIPTION
There were two input fields with the same ID. Changed selector to be more specific. #custom_form32 #req_email
