### PR TITLE
Update S001165.yaml

### DIFF
--- a/members/S001165.yaml
+++ b/members/S001165.yaml
@@ -12,7 +12,7 @@ contact_form:
         - name: zip4
           selector: "#zip4"
           value: $ADDRESS_ZIP4
-          required: false
+          required: true
     - click_on:
         - value: Go To Next Step
           selector: "#emailForm input[name='submit']"


### PR DESCRIPTION
Even though the zip4 field is not marked as required on the web site, submitting the form without it fails.
