### PR TITLE
Add phone number breakdown to variables.yaml

### DIFF
--- a/support/variables.yaml
+++ b/support/variables.yaml
@@ -43,15 +43,18 @@
 "$PHONE_PARENTHESES":
   description: A 10 or 11 digit telephone number with parentheses around the area code
   example: "(202) 555-1234"
+"$PHONE_HYPHENS":
+  description: A 10 or 11 digit telephone number with hyphens between the numbers
+  example: "202-555-1234"
 "$PHONE_AREA_CODE":
   description: The area code for a phone number without styling
-  example: 573
+  example: 202
 "$PHONE_EXCHANGE_CODE":
   description: The exchange for a phone number
   example: 555
 "$PHONE_SUBSCRIBER_NUMBER":
   description: The subscriber number for a phone
-  example: 5555
+  example: 1234
 "$EMAIL":
   description: Primary email address
   example: thepresident@example.com

--- a/support/variables.yaml
+++ b/support/variables.yaml
@@ -43,6 +43,15 @@
 "$PHONE_PARENTHESES":
   description: A 10 or 11 digit telephone number with parentheses around the area code
   example: "(202) 555-1234"
+"$PHONE_AREA_CODE":
+  description: The area code for a phone number without styling
+  example: 573
+"$PHONE_EXCHANGE_CODE":
+  description: The exchange for a phone number
+  example: 555
+"$PHONE_SUBSCRIBER_NUMBER":
+  description: The subscriber number for a phone
+  example: 5555
 "$EMAIL":
   description: Primary email address
   example: thepresident@example.com


### PR DESCRIPTION
For some forms on the state level, we need to break down the phone number more and I thought I'd set the variable here hoping they'd trickle down even if this doesn't apply to any current yamls.