### PR TITLE
Phantom can't use head elements in selector

### DIFF
--- a/members/B000589.yaml
+++ b/members/B000589.yaml
@@ -58,8 +58,8 @@ contact_form:
         - value: Submit
           selector: "#main form input[type='submit'][value='Submit']"
     - find:
-        - value: "You've contacted the John Boehner office!"
-        - selector: "title"
+        - selector: "body"
+          value: ".*Thanks for contacting us.*"
   success:
     headers:
       status: 200


### PR DESCRIPTION
Appears phantom can accept regexp in find: https://github.com/EFForg/phantom-of-the-capitol/blob/master/app/models/congress_member.rb#L255

Using regexp to avoid potential spacing issues.