### PR TITLE
The ReplyChoice radio's value is now "Respond" not "Yes"

### DIFF
--- a/members/D000598.yaml
+++ b/members/D000598.yaml
@@ -94,12 +94,7 @@ contact_form:
     - choose:
       - name: ctl00$ctl09$ReplyChoice
         selector: "#ctl00_ctl09_ReplyChoice_0"
-        value: "yes"
-        required: Yes
-    - check:
-      - name: ctl00$ctl09$SubscribeChoice
-        selector: "#ctl00_ctl09_SubscribeChoice"
-        value: "yes"
+        value: "Respond"
         required: Yes
     - click_on:
       - value: Submit


### PR DESCRIPTION
The #ctl00_ctl09_ReplyChoice_0 radio's value is now "Respond" not "Yes" -- and ctl00$ctl09$SubscribeChoice's value is also no longer "yes" but why check it at all?