### PR TITLE
Wait 2 seconds instead of one after click

### DIFF
--- a/members/B001230.yaml
+++ b/members/B001230.yaml
@@ -159,7 +159,7 @@ contact_form:
         - value: Send
           selector: "#side-search-btn"
     - wait:
-        - value: 1
+        - value: 2
     - find:
         - selector: "p"
           value: "Thank you for contacting me."


### PR DESCRIPTION
This form fails intermittently when waiting 1 second. Recommend 2 to give extra leeway.