### PR TITLE
[H001061] YAML was missing drop down for state

### DIFF
--- a/members/H001061.yaml
+++ b/members/H001061.yaml
@@ -41,6 +41,11 @@ contact_form:
         value: "$MESSAGE"
         required: Yes
     - select:
+      - name: field_629c9999-8309-4a0b-b0ff-67c167b712b5
+        selector: "#field_629c9999-8309-4a0b-b0ff-67c167b712b5"
+        value: $ADDRESS_STATE_POSTAL_ABBREV
+        required: Yes
+        options: US_STATES_AND_MPCS
       - name: field_89f02d5d-f5d9-46e9-880e-bb15e9254713
         selector: "#field_89f02d5d-f5d9-46e9-880e-bb15e9254713"
         value: "$NAME_PREFIX"


### PR DESCRIPTION
State is required for the form to submit. By default "North Dakota" was selected and the form was submitting, but this makes it impossible for clients to customize the state. Fixed by adding a YAML definition for the state selector.