### PR TITLE
[I000055] YAML was missing drop down for state

### DIFF
--- a/members/I000055.yaml
+++ b/members/I000055.yaml
@@ -52,6 +52,11 @@ contact_form:
         options:
           max_length: 10000
     - select:
+      - name: field_69395e1d-910c-43ca-bd6c-43c2ec98a586
+        selector: "#field_69395e1d-910c-43ca-bd6c-43c2ec98a586"
+        value: $ADDRESS_STATE_POSTAL_ABBREV
+        required: Yes
+        options: US_STATES_AND_MPCS
       - name: field_158b2b90-6381-4626-beeb-7b43c917be66
         selector: "#field_158b2b90-6381-4626-beeb-7b43c917be66"
         value: $TOPIC


### PR DESCRIPTION
State is required for the form to submit. By default "Georgia" was selected and the form was submitting, but this makes it impossible for clients to customize the state. Fixed by adding a YAML definition for the state selector.