### PR TITLE
[J000293] YAML was missing drop down for state

### DIFF
--- a/members/J000293.yaml
+++ b/members/J000293.yaml
@@ -47,6 +47,11 @@ contact_form:
         value: "$MESSAGE"
         required: Yes
     - select:
+      - name: field_f062734c-8f9c-4e35-8a6d-e8c120afcdf8
+        selector: "#field_f062734c-8f9c-4e35-8a6d-e8c120afcdf8"
+        value: $ADDRESS_STATE_POSTAL_ABBREV
+        required: Yes
+        options: US_STATES_AND_MPCS
       - name: field_f33b2309-b7af-40ca-aaf8-e40952fff259
         selector: "#field_f33b2309-b7af-40ca-aaf8-e40952fff259"
         value: "$TOPIC"


### PR DESCRIPTION
State is required for the form to submit. By default "Wisconsin" was selected and the form was submitting, but this makes it impossible for clients to customize the state. Fixed by adding a YAML definition for the state selector.