### PR TITLE
[K000360] YAML was missing drop down for state

### DIFF
--- a/members/K000360.yaml
+++ b/members/K000360.yaml
@@ -69,6 +69,11 @@ contact_form:
         value: $MESSAGE
         required: Yes
     - select:
+      - name: State
+        selector: "form#thisForm select[name='State']"
+        value: $ADDRESS_STATE_POSTAL_ABBREV
+        required: Yes
+        options: US_STATES_AND_MPCS
       - name: Prefix
         selector: "form#thisForm select[name='Prefix']"
         value: $NAME_PREFIX


### PR DESCRIPTION
State is required for the form to submit. By default "Illinois" was selected and the form was submitting, but this makes it impossible for clients to customize the state. Fixed by adding a YAML definition for the state selector.