### PR TITLE
[K000367] YAML was missing drop down for state

### DIFF
--- a/members/K000367.yaml
+++ b/members/K000367.yaml
@@ -46,6 +46,11 @@ contact_form:
           value: $MESSAGE
           required: true
     - select:
+        - name: field_1a985454-67c9-42fc-bbc2-ce957d2633d6
+          selector: "#field_1a985454-67c9-42fc-bbc2-ce957d2633d6"
+          value: $ADDRESS_STATE_POSTAL_ABBREV
+          required: Yes
+          options: US_STATES_AND_MPCS
         - name: field_14306be6-1d30-4925-afba-1bc433f550d7
           selector: "#field_14306be6-1d30-4925-afba-1bc433f550d7"
           value: $TOPIC


### PR DESCRIPTION
State is required for the form to submit. By default "Minnesota" was selected and the form was submitting, but this makes it impossible for clients to customize the state. Fixed by adding a YAML definition for the state selector.