### PR TITLE
No need to click submit twice on ZIP verification.

### DIFF
--- a/members/B001295.yaml
+++ b/members/B001295.yaml
@@ -13,9 +13,6 @@ contact_form:
       selector: "#zip4"
       value: $ADDRESS_ZIP4
       required: true
-  - click_on: 
-    - value: Go To Next Step
-      selector: "#emailForm #submit"
   - wait:
     - value: 1
   - javascript:


### PR DESCRIPTION
The javascript-based click added in 0b02c309 makes the old "click_on" redundant.