### PR TITLE
Remove redundant pre-javascript submission step for L000551.

### DIFF
--- a/members/L000551.yaml
+++ b/members/L000551.yaml
@@ -65,9 +65,6 @@ contact_form:
             - Ms.
             - Dr.
             - Miss.
-    - click_on:
-        - value: Submit
-          selector: "#ctl00_ctl30_SubmitButton"
     - javascript:
         - value: document.querySelector("#ctl00_ctl30_Body").value = document.querySelector("#ctl00_ctl30_Body").value.replace(/"/g, '');
     - click_on:


### PR DESCRIPTION
The first submission step is often succeeding, so the javascript fails since the text field no longer exists to manipulate after submission.