### PR TITLE
Update S000250

### DIFF
--- a/members/S000250.yaml
+++ b/members/S000250.yaml
@@ -9,9 +9,12 @@ contact_form:
           selector: "#required-zip5"
           value: $ADDRESS_ZIP5
           required: true
+        - name: zip4
+          selector: '#zip4'
+          value: $ADDRESS_ZIP4
+          required: true
     - click_on:
-        - 
-          selector: "#submit"
+        - selector: "#submit"
     - fill_in:
         - name: required-first
           selector: "#required-first"


### PR DESCRIPTION
In some situations, a 4 ZIP was required to continue to the 2nd form even though it is not marked as required on the form.

I have added a fill_in action and set it to required to true so it covers these cases.