### PR TITLE
Update W000820

### DIFF
--- a/members/W000820.yaml
+++ b/members/W000820.yaml
@@ -17,7 +17,7 @@ contact_form:
     - value: Go To Next Step
       selector: "#emailForm #submit"
   - javascript:
-    - value: "document.querySelector('#emailForm #submit').click();"
+    - value: 'if (document.querySelector("#emailForm #submit")) {document.querySelector("#emailForm #submit").click()}'
   - find: 
     - selector: "#required-prefix"
   - javascript:


### PR DESCRIPTION
For some reason there are two actions that handle the ZIP submission click - 'click_on' and a javascript click. This is causing errors when the first click works.

Not sure why there are two actions handling this, I believe one is all you need. However, if two are need for some other reason , I have added some logic to check if the button has already been clicked to prevent it timing out.