### PR TITLE
remove trailing tab whitespace, technically invalid yaml and blows up…

### DIFF
--- a/members/M001176.yaml
+++ b/members/M001176.yaml
@@ -107,7 +107,7 @@ contact_form:
     - click_on:
         - value: Send
           selector: "#side-search-btn"
-    - javascript:		
+    - javascript:
         - value: "document.querySelector('#side-search-btn') && document.querySelector('#side-search-btn').click();"
     - find:
         - selector: "h2"


### PR DESCRIPTION
… PyYAML's parser