### PR TITLE
remove TOPIC "Other" selection

### DIFF
--- a/members/G000555.yaml
+++ b/members/G000555.yaml
@@ -91,8 +91,6 @@ contact_form:
               Welfare: 000985E5-5056-A066-6004-FD5B089A0C10
               Women's Issues: 00098665-5056-A066-603D-A7EFCE05FDBE
               Other: 0009867F-5056-A066-6001-7BA85FA3979E
-    - click_on:
-        - selector: "#issue-30"  
     - javascript:
         - value: document.querySelector("#input-4154995F-09DE-911F-DD8B-93796597BB52").value = document.querySelector("#input-4154995F-09DE-911F-DD8B-93796597BB52").value.replace(/"/g, '');
     - javascript:


### PR DESCRIPTION
The removed step overrides the topic selected from the different radio buttons.  It isn't needed for the form to work (Sen. Harris similar form works without this step as well).  Thanks!