### PR TITLE
Dismiss newsletter signup modal for Y000064

### DIFF
--- a/members/Y000064.yaml
+++ b/members/Y000064.yaml
@@ -5,6 +5,8 @@ contact_form:
   steps:
     - visit: "https://www.young.senate.gov/contact/email-todd"
     - click_on:
+        - selector: ".close"
+    - click_on:
         - selector: ".opinion"
     - find:
         - selector: "#input-B03E05C4-4040-F985-52CD-9CA44623DE5E"


### PR DESCRIPTION
Young's form now appears to show a newsletter signup modal for new visitors, which must be explicitly dismissed. Do this before even starting to fill out the form.

@j-ro Hopefully this works for your setup as well, if not let me know.