### PR TITLE
add wait post-visit to handle deferred form elements

### DIFF
--- a/members/C001047.yaml
+++ b/members/C001047.yaml
@@ -4,8 +4,8 @@ contact_form:
   action: "https://www.capito.senate.gov/contact/contact-shelley"
   steps:
     - visit: "https://www.capito.senate.gov/contact/contact-shelley"
-    - wait:
-        - value: 3
+    - find:
+        - selector: "#actions"
     - select:
         - name: input_AE7457DD-4040-F985-52CD-B99385041C51
           selector: "#actions"


### PR DESCRIPTION
Webforms requiring a YAML step to initially load form fields typically use a wait post-visit, adding Capito to keep in line with this :)