### PR TITLE
Remove trailing tabs/spaces from Sasse's YAML

### DIFF
--- a/members/S001197.yaml
+++ b/members/S001197.yaml
@@ -37,15 +37,15 @@ contact_form:
           required: true
         - name: field_423DB2CF-5A0E-4DDD-9ABF-9C3D7FD2D7D4
           selector: "#field_423DB2CF-5A0E-4DDD-9ABF-9C3D7FD2D7D4"
-          value: $MESSAGE 
+          value: $MESSAGE
           required: true
           options:
             max_length: 2500
-        - name: captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99			
-          selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99"			
-          captcha_selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99_container img"			      
-          captcha_id_selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99_container img"			      
-          value: "$CAPTCHA_SOLUTION"			
+        - name: captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99
+          selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99"
+          captcha_selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99_container img"
+          captcha_id_selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99_container img"
+          value: "$CAPTCHA_SOLUTION"
           required: true
     - select:
         - name: field_2647C301-6F8A-4A2F-A7AD-6AB2BA694E46


### PR DESCRIPTION
Sasse's YAML has trailing tabs, preventing Python's YAML library from reading the file properly. Remove these trailing tabs so it will work again.