### PR TITLE
Update Cornyn's form config to reflect prefix change

### DIFF
--- a/members/C001056.yaml
+++ b/members/C001056.yaml
@@ -44,6 +44,43 @@ contact_form:
             Transportation: transportation
             Veterans: veterans
             Welfare: welfare
+        - name: "submitted[prefix_select]"
+          selector: "#edit-submitted-prefix-select"
+          value: $NAME_PREFIX
+          required: true
+          options:
+            "Chaplain": "Chapln"
+            "Doctor": "Dr"
+            "Mr.": "Mr"
+            "Ms.": "Ms"
+            "Mrs.": "Mrs"
+            "Professor": "Prof"
+            "Rabbi": "Rabbi"
+            "Reverend": "Rev"
+            "Reverends": "Revs"
+            "The Honorable": "TheHon"
+            "Admiral": "ADM"
+            "Brigadier General": "BrigGen"
+            "Captain": "Capt"
+            "Chief Warrant Officer": "CWO"
+            "Colonel": "Col"
+            "Commander": "CDR"
+            "Corporal": "Cpl"
+            "Ensign": "ENS"
+            "First Lieutenant": "1stLt"
+            "General": "Gen"
+            "Lieutenant": "LT"
+            "Lieutenant Colonel": "LtCol"
+            "Lieutenant Commander": "LCDR"
+            "Lieutenant General": "LtGen"
+            "Lieutenant (Junior Grade)": "LTJG"
+            "Major": "Maj"
+            "Major General": "MajGen"
+            "Master Sergeant": "MSgt"
+            "Rear Admiral": "RADM"
+            "Second Lieutenant": "2ndLt"
+            "Sergeant": "Sgt"
+            "Vice Admiral": "VADM"
         - name: "submitted[state]"
           selector: "#edit-submitted-state"
           value: $ADDRESS_STATE_POSTAL_ABBREV
@@ -108,10 +145,6 @@ contact_form:
             Wisconsin: WI
             Wyoming: WY
     - fill_in:
-        - name: "submitted[prefix_optional]"
-          selector: "#edit-submitted-prefix-optional"
-          value: $NAME_PREFIX
-          required: false
         - name: "submitted[first_name]"
           selector: "#edit-submitted-first-name"
           value: $NAME_FIRST


### PR DESCRIPTION
Cornyn's form no longer has a text box for a person's prefix. Instead, it now has a drop-down select. Update the form config to relect this change.