### PR TITLE
Close newsletter signup overlay on Hassan's form

### DIFF
--- a/members/H001076.yaml
+++ b/members/H001076.yaml
@@ -5,6 +5,7 @@ contact_form:
   steps:
     - visit: "https://www.hassan.senate.gov/contact/email"
     - click_on:
+        - selector: "button.close"
         - selector: ".opinion"
     - find:
         - selector: "#input-B03E05C4-4040-F985-52CD-9CA44623DE5E"


### PR DESCRIPTION
Hassan's form added a newsletter signup which covers part of the page. Close this overlay before attempting to proceed with the form.