### PR TITLE
Remove verify email input from Cruz's form config

### DIFF
--- a/members/C001098.yaml
+++ b/members/C001098.yaml
@@ -33,16 +33,12 @@ contact_form:
           selector: "#gen-fieldid-19"
           value: $EMAIL
           required: true
-        - name: vemail
-          selector: "#gen-fieldid-21"
-          value: $EMAIL
-          required: true
         - name: SUBJECT
-          selector: "#gen-fieldid-25"
+          selector: "#gen-fieldid-23"
           value: $SUBJECT
           required: true
         - name: MSG
-          selector: "#gen-fieldid-27"
+          selector: "#gen-fieldid-25"
           value: $MESSAGE
           required: true
     - select:
@@ -77,11 +73,10 @@ contact_form:
             Sister: Sister
             Technical Sergeant: Technical Sergeant
         - name: TOPIC
-          selector: "#gen-fieldid-23"
+          selector: "#gen-fieldid-21"
           value: $TOPIC
           required: true
           options:
-            "-- please select a topic --": "null"
             Agriculture: Agriculture
             Animal Welfare: Animal Welfare
             Banking/Housing: Banking/Housing
@@ -117,7 +112,7 @@ contact_form:
           selector: "input[type='radio'][name='respond'][value='Yes']"
           value: "Yes"
     - javascript:
-        - value: document.querySelector("#gen-fieldid-27").value = document.querySelector("#gen-fieldid-27").value.replace(/"/g, '');
+        - value: document.querySelector("#gen-fieldid-25").value = document.querySelector("#gen-fieldid-27").value.replace(/"/g, '');
     - recaptcha:
         - value: true
     - click_on:


### PR DESCRIPTION
Ted Cruz's contact form had a verify email input in the past, but it seems to have been removed. Remove this from the YAML and adjust the IDs for some other inputs as it appears they have changed.