### PR TITLE
Change back selector for state dropdown for Schumer

### DIFF
--- a/members/S000148.yaml
+++ b/members/S000148.yaml
@@ -73,8 +73,8 @@ contact_form:
             - Mrs.
             - Ms.
             - Dr.
-        - name: states_abbreviated
-          selector: "#states_abbreviated"
+        - name: state
+          selector: "#state"
           value: $ADDRESS_STATE_POSTAL_ABBREV
           required: true
           options:


### PR DESCRIPTION
Apparently they changed the id/name back to what it originally was. This reverts commit d7ddd5ca5ea31c8f772155f616494d49cee34698.