### PR TITLE
remove trailing tab character

### DIFF
--- a/members/S001197.yaml
+++ b/members/S001197.yaml
@@ -41,7 +41,7 @@ contact_form:
           required: true
           options:
             max_length: 2500
-        - name: captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99			
+        - name: captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99
           selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99"
           captcha_selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99_container img"
           captcha_id_selector: "#captcha_95CD8B31-5184-42D1-B156-FBC53AE06B99_container img"


### PR DESCRIPTION
this line had a tab character at the end of it which is breaking YAML parsing in Python:

```
yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "<string>", line 45, column 61:
     ... 8B31-5184-42D1-B156-FBC53AE06B99			
                                         ^
```