### PR TITLE
2019-06-27 Update C001088

### DIFF
--- a/members/C001088.yaml
+++ b/members/C001088.yaml
@@ -164,7 +164,7 @@ contact_form:
             Miscellaneous: MISC
             National Service: NATSERV
     - javascript:
-        - value: document.querySelector("#input_FF882848-5056-A066-60D7-1A3C4C6ADC8D").value = document.querySelector("input_FF882848-5056-A066-60D7-1A3C4C6ADC8D").value.replace(/"/g, '');
+        - value: document.querySelector("#input-FF88260A-5056-A066-6070-B369711DCB30").value = document.querySelector("#input-FF88260A-5056-A066-6070-B369711DCB30").value.replace(/"/g, '');
     - click_on:
         - value: Submit
           selector: input.btn


### PR DESCRIPTION
C001088 has JS to replace the quotation marks (") with an empty string.  The selector was not anywhere on the form.  I looked at the history of the changes to this JS selector, and previously it was affecting the message field.  I updated the JS to select the message field.   

Feel free to provide feedback if this is not the intention of this JS.