### PR TITLE
2020-05-15 - Remove header and alert from C001047

### DIFF
--- a/members/C001047.yaml
+++ b/members/C001047.yaml
@@ -5,10 +5,13 @@ contact_form:
   steps:
     - visit: "https://www.capito.senate.gov/contact/share-your-opinion"
     - javascript:
-        - value: "Array.prototype.forEach.call(document.querySelectorAll('style,[rel=\"stylesheet\"],[type=\"text/css\"]'), function(element){
-try{ element.parentNode.removeChild(element) } catch(err){} });"
+        - value: "Array.prototype.forEach.call(document.querySelectorAll('style,[rel=\"stylesheet\"],[type=\"text/css\"]'), function(element){try{ element.parentNode.removeChild(element) } catch(err){} });"
     - find:
         - selector: "#input-AB59F0AE-4040-F985-52CD-AA63153C7925"
+    - javascript:
+        - value: 'el = document.getElementsByClassName("SiteLayout__header"); el[0].remove();'
+    - javascript:
+        - value: 'document.getElementById("covid-alert").remove();'
     - fill_in:
         - name: input_AB59F0AE-4040-F985-52CD-AA63153C7925
           selector: "#input-AB59F0AE-4040-F985-52CD-AA63153C7925"


### PR DESCRIPTION
Good evening-
This form has a header that flops down on top of the elements we wish to interact with when the styling is stripped from the page.  There's another alert that covers the elements that I'm removing.  Both of these items make it so we can't interact with the fields.  I left the items in separate directives under the assumption that the covid alert will be unnecessary at some point.  

Comments welcome as always.
Thanks -- Jason