### PR TITLE
2020-07-21 - Updates R000122

### DIFF
--- a/members/R000122.yaml
+++ b/members/R000122.yaml
@@ -243,10 +243,12 @@ contact_form:
         - value: document.querySelector("#g-recaptcha-response").style.display = "block";
     - recaptcha:
         - value: true
+    - javascript:
+        - value: document.querySelector("#g-recaptcha-response").style.display = "none";
     - click_on:
         - selector: ".btn[type=submit]"
   success:
     headers:
       status: 200
     body:
-      contains: THANK YOU
+      contains: Your message will be reviewed


### PR DESCRIPTION
Good Afternoon-
This PR updates R000122.  Exposing the g-captcha-response element covers up the submit button, causing the form to fail for us.  This PR just re-hides the element after the captcha is solved to resolve it.
Also note the changed success text.
Let me know if there are any questions.
Thanks -- Jason C.