### PR TITLE
2021-08-07 S001217 add max length to message field

### DIFF
--- a/members/S001217.yaml
+++ b/members/S001217.yaml
@@ -43,6 +43,8 @@ contact_form:
           required: true
           options:
             max_length: 500
+    - javascript:
+        - value: document.querySelector("#field_5BEA2CE5-75D6-4043-A93F-55A46FDDB702").value = document.querySelector("#field_5BEA2CE5-75D6-4043-A93F-55A46FDDB702").value.replace(/\n/g, ' ');
     - select:
         - name: "field_3EA91422-F58D-4F36-9192-1ADA36E8F959"
           selector: "#field_3EA91422-F58D-4F36-9192-1ADA36E8F959"

--- a/members/S001217.yaml
+++ b/members/S001217.yaml
@@ -41,6 +41,8 @@ contact_form:
           selector: "#field_5BEA2CE5-75D6-4043-A93F-55A46FDDB702"
           value: $MESSAGE
           required: true
+          options:
+            max_length: 500
     - select:
         - name: "field_3EA91422-F58D-4F36-9192-1ADA36E8F959"
           selector: "#field_3EA91422-F58D-4F36-9192-1ADA36E8F959"
@@ -111,4 +113,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: "Thank you, your message"
+      contains: "Thank you"


### PR DESCRIPTION
The message field has a 500 character max length, and it's causing us some problems.  Additionally, the form treats newlines as 2 characters, so when we programmatically count, we end up over the max if there are newline characters.  The bit of JS replaces newlines with a single space.  Also updates the success message.