### PR TITLE
2021-10-09 rewrite C001098

### DIFF
--- a/members/C001098.yaml
+++ b/members/C001098.yaml
@@ -169,7 +169,11 @@ contact_form:
     - click_on:
         - value: Submit
           selector: 'button[type="submit"].btn'
+    ## The success screen has no new text on it, rather it just has an image.  Doing a find on the image alt text here to see if it is present before declaring success by the text in the body.
+    - find:
+        - selector: 'img[alt="thank you from ted image"]'
   success:
     headers:
       status: 200
-    selector: 'img[alt="thank you from ted image"]'
+    body:
+      contains: "Write To Ted"


### PR DESCRIPTION
This is a re-write for Sen. Cruz's form.

Note that there's no success target text that appears.  Rather, it's just an image.  Our programs allow a ```selector``` to be used as a success criteria, so if it's possible, I'd like to use that here.  @j-ro, let me know if this is possible.  If not, I'll think of something else.

![image](https://user-images.githubusercontent.com/28363571/136664378-8b7ef29f-ee33-4478-a32c-ad2a3bb8f2cd.png)
