### PR TITLE
2022-01-17 - Update B001230 (Baldwin - WI)

### DIFF
--- a/members/B001230.yaml
+++ b/members/B001230.yaml
@@ -176,10 +176,8 @@ contact_form:
         - value: document.querySelector('#input-FDC0100A-9282-D116-5180-CB8642FD2C7A').click();
     - click_on:
         - selector: ".controls .btn"
-    - javascript:
-          value: document.querySelector('.controls .btn').click();
   success:
     headers:
       status: 200
     body:
-      contains: ""
+      contains: "Thank You"


### PR DESCRIPTION
Removes second JS click as the element is not present after the first click.  Also updates the success message.