### PR TITLE
Update B001277.yaml

### DIFF
--- a/members/B001277.yaml
+++ b/members/B001277.yaml
@@ -140,4 +140,4 @@ contact_form:
     headers:
       status: 200
     body:
-      contains: "I appreciate hearing from you"
+      contains: ""


### PR DESCRIPTION
Blanked out success text. We have to populate the form using js, when the submission renders the success text won't appear